### PR TITLE
Hotfix: No rotation when mode_props[is-current] is undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This extension uses Mutter's D-Bus API, so it works on both X11 and Wayland.
 Original project was licensed under GPL V2. With the inactivity of the current 
 maintainer kosmospredanie. This fork has been upgraded to GPL V3.
 
-Copyright (C) 2022  kosmospredanie, shyzus, Shinigaminai
+Copyright (C) 2022  kosmospredanie, shyzus, Shinigaminai, efosmark
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/screen-rotate@shyzus.github.io/busUtils.js
+++ b/screen-rotate@shyzus.github.io/busUtils.js
@@ -1,6 +1,6 @@
 /* busUtils.js
 *
-* Copyright (C) 2022  kosmospredanie
+* Copyright (C) 2022  kosmospredanie, efosmark
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by

--- a/screen-rotate@shyzus.github.io/busUtils.js
+++ b/screen-rotate@shyzus.github.io/busUtils.js
@@ -36,10 +36,12 @@ var Monitor = class Monitor {
             let mode = modes[i].unpack();
             let id = mode[0].unpack();
             let mode_props = mode[6].unpack();
-            let is_current = mode_props['is-current'].unpack().get_boolean();
-            if (is_current) {
-                this.current_mode_id = id;
-                break;
+            if ('is-current' in mode_props) {
+                let is_current = mode_props['is-current'].unpack().get_boolean();
+                if (is_current) {
+                    this.current_mode_id = id;
+                    break;
+                }
             }
         }
 

--- a/screen-rotate@shyzus.github.io/metadata.json
+++ b/screen-rotate@shyzus.github.io/metadata.json
@@ -3,7 +3,7 @@
   "description": "Enable screen rotation regardless of touch mode. Fork of Screen Autorotate by Kosmospredanie.",
   "url": "https://github.com/shyzus/gnome-shell-extension-screen-autorotate",
   "uuid": "screen-rotate@shyzus.github.io",
-  "version": 5,
+  "version": 8,
   "settings-schema": "org.gnome.shell.extensions.screen-rotate",
   "gettext-domain": "gnome-shell-extension-screen-rotate",
   "session-modes": ["user", "unlock-dialog"],


### PR DESCRIPTION
Fixes issue #5 

This proposed change adds an existence-check to the `'is-current'` key in `mode_props`. 

```
(gnome-shell:27944): Gjs-WARNING **: 21:05:59.531: JS ERROR: TypeError: mode_props['is-current'] is undefined
Monitor@/~/.local/share/gnome-shell/extensions/screen-rotate@shyzus.github.io/busUtils.js:40:34
DisplayConfigState/<@/~/.local/share/gnome-shell/extensions/screen-rotate@shyzus.github.io/busUtils.js:88:27
DisplayConfigState@/~/.local/share/gnome-shell/extensions/screen-rotate@shyzus.github.io/busUtils.js:87:18
get_state/</<@/~/.local/share/gnome-shell/extensions/screen-rotate@shyzus.github.io/rotator.js:60:35
```