### PR TITLE
Refactored to work under GNOME 45

### DIFF
--- a/screen-rotate@shyzus.github.io/busUtils.js
+++ b/screen-rotate@shyzus.github.io/busUtils.js
@@ -16,158 +16,157 @@
 * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-'use strict';
+import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
 
-const { GLib, Gio } = imports.gi;
-
-var Methods = Object.freeze({
-    'verify': 0,
-    'temporary': 1,
-    'persistent': 2
+export const Methods = Object.freeze({
+  'verify': 0,
+  'temporary': 1,
+  'persistent': 2
 });
 
-var Monitor = class Monitor {
-    constructor(variant) {
-        let unpacked = variant.unpack();
-        this.connector = unpacked[0].unpack()[0].unpack();
+export const Monitor = class Monitor {
+  constructor(variant) {
+    let unpacked = variant.unpack();
+    this.connector = unpacked[0].unpack()[0].unpack();
 
-        let modes = unpacked[1].unpack();
-        for (let i = 0; i < modes.length; i++) {
-            let mode = modes[i].unpack();
-            let id = mode[0].unpack();
-            let mode_props = mode[6].unpack();
-            if ('is-current' in mode_props) {
-                let is_current = mode_props['is-current'].unpack().get_boolean();
-                if (is_current) {
-                    this.current_mode_id = id;
-                    break;
-                }
-            }
+    let modes = unpacked[1].unpack();
+    for (let i = 0; i < modes.length; i++) {
+      let mode = modes[i].unpack();
+      let id = mode[0].unpack();
+      let mode_props = mode[6].unpack();
+      if ('is-current' in mode_props) {
+        let is_current = mode_props['is-current'].unpack().get_boolean();
+        if (is_current) {
+          this.current_mode_id = id;
+          break;
         }
-
-        let props = unpacked[2].unpack();
-        if ('is-underscanning' in props) {
-            this.is_underscanning = props['is-underscanning'].unpack().get_boolean();
-        } else {
-            this.is_underscanning = false;
-        }
-        if ('is-builtin' in props) {
-            this.is_builtin = props['is-builtin'].unpack().get_boolean();
-        } else {
-            this.is_builtin = false;
-        }
+      }
     }
+
+    let props = unpacked[2].unpack();
+    if ('is-underscanning' in props) {
+      this.is_underscanning = props['is-underscanning'].unpack().get_boolean();
+    } else {
+      this.is_underscanning = false;
+    }
+    if ('is-builtin' in props) {
+      this.is_builtin = props['is-builtin'].unpack().get_boolean();
+    } else {
+      this.is_builtin = false;
+    }
+  }
 }
 
-var LogicalMonitor = class LogicalMonitor {
-    constructor(variant) {
-        let unpacked = variant.unpack();
-        this.x = unpacked[0].unpack();
-        this.y = unpacked[1].unpack();
-        this.scale = unpacked[2].unpack();
-        this.transform = unpacked[3].unpack();
-        this.primary = unpacked[4].unpack();
-        // [ [connector, vendor, product, serial]* ]
-        this.monitors = unpacked[5].deep_unpack();
-        this.properties = unpacked[6].unpack();
-        for (let key in this.properties) {
-            this.properties[key] = this.properties[key].unpack().unpack();
-        }
+export const LogicalMonitor = class LogicalMonitor {
+  constructor(variant) {
+    let unpacked = variant.unpack();
+    this.x = unpacked[0].unpack();
+    this.y = unpacked[1].unpack();
+    this.scale = unpacked[2].unpack();
+    this.transform = unpacked[3].unpack();
+    this.primary = unpacked[4].unpack();
+    // [ [connector, vendor, product, serial]* ]
+    this.monitors = unpacked[5].deep_unpack();
+    this.properties = unpacked[6].unpack();
+    for (let key in this.properties) {
+      this.properties[key] = this.properties[key].unpack().unpack();
     }
+  }
 }
 
-var DisplayConfigState = class DisplayConfigState {
-    constructor(result) {
-        let unpacked = result.unpack();
+export const DisplayConfigState = class DisplayConfigState {
+  constructor(result) {
+    let unpacked = result.unpack();
 
-        this.serial = unpacked[0].unpack();
+    this.serial = unpacked[0].unpack();
 
-        this.monitors = [];
-        let monitors = unpacked[1].unpack();
-        monitors.forEach(monitor_packed => {
-            let monitor = new Monitor(monitor_packed);
-            this.monitors.push(monitor);
-        });
+    this.monitors = [];
+    let monitors = unpacked[1].unpack();
+    monitors.forEach(monitor_packed => {
+      let monitor = new Monitor(monitor_packed);
+      this.monitors.push(monitor);
+    });
 
-        this.logical_monitors = [];
-        let logical_monitors = unpacked[2].unpack();
-        logical_monitors.forEach(lmonitor_packed => {
-            let lmonitor = new LogicalMonitor(lmonitor_packed);
-            this.logical_monitors.push(lmonitor);
-        });
+    this.logical_monitors = [];
+    let logical_monitors = unpacked[2].unpack();
+    logical_monitors.forEach(lmonitor_packed => {
+      let lmonitor = new LogicalMonitor(lmonitor_packed);
+      this.logical_monitors.push(lmonitor);
+    });
 
-        this.properties = unpacked[3].unpack();
-        for (let key in this.properties) {
-            this.properties[key] = this.properties[key].unpack().unpack();
+    this.properties = unpacked[3].unpack();
+    for (let key in this.properties) {
+      this.properties[key] = this.properties[key].unpack().unpack();
+    }
+  }
+
+  get builtin_monitor() {
+    for (let i = 0; i < this.monitors.length; i++) {
+      let monitor = this.monitors[i];
+      if (monitor.is_builtin) {
+        return monitor;
+      }
+    }
+    return null;
+  }
+
+  get_monitor(connector) {
+    for (let i = 0; i < this.monitors.length; i++) {
+      let monitor = this.monitors[i];
+      if (monitor.connector === connector) {
+        return monitor;
+      }
+    }
+    return null;
+  }
+
+  get_logical_monitor_for(connector) {
+    for (let i = 0; i < this.logical_monitors.length; i++) {
+      let lmonitor = this.logical_monitors[i];
+      for (let j = 0; j < lmonitor.monitors.length; j++) {
+        let lm_connector = lmonitor.monitors[j][0];
+        if (connector === lm_connector) {
+          return lmonitor;
         }
+      }
+    }
+    return null;
+  }
+
+  pack_to_apply(method) {
+    let packing = [this.serial, method, [], {}];
+    let logical_monitors = packing[2];
+    let properties = packing[3];
+
+    this.logical_monitors.forEach(lmonitor => {
+      let lmonitor_pack = [
+        lmonitor.x,
+        lmonitor.y,
+        lmonitor.scale,
+        lmonitor.transform,
+        lmonitor.primary,
+        []
+      ];
+      let monitors = lmonitor_pack[5];
+      for (let i = 0; i < lmonitor.monitors.length; i++) {
+        let connector = lmonitor.monitors[i][0];
+        let monitor = this.get_monitor(connector);
+        monitors.push([
+          connector,
+          monitor.current_mode_id,
+          {
+            'enable_underscanning': new GLib.Variant('b', monitor.is_underscanning)
+          }
+        ]);
+      }
+      logical_monitors.push(lmonitor_pack);
+    });
+
+    if ('layout-mode' in this.properties) {
+      properties['layout-mode'] = new GLib.Variant('b', this.properties['layout-mode']);
     }
 
-    get builtin_monitor() {
-        for (let i = 0; i < this.monitors.length; i++) {
-            let monitor = this.monitors[i];
-            if (monitor.is_builtin) {
-                return monitor;
-            }
-        }
-        return null;
-    }
-
-    get_monitor(connector) {
-        for (let i = 0; i < this.monitors.length; i++) {
-            let monitor = this.monitors[i];
-            if (monitor.connector === connector) {
-                return monitor;
-            }
-        }
-        return null;
-    }
-
-    get_logical_monitor_for(connector) {
-        for (let i = 0; i < this.logical_monitors.length; i++) {
-            let lmonitor = this.logical_monitors[i];
-            for (let j = 0; j < lmonitor.monitors.length; j++) {
-                let lm_connector = lmonitor.monitors[j][0];
-                if (connector === lm_connector) {
-                    return lmonitor;
-                }
-            }
-        }
-        return null;
-    }
-
-    pack_to_apply(method) {
-        let packing = [ this.serial, method, [], {} ];
-        let logical_monitors = packing[2];
-        let properties = packing[3];
-
-        this.logical_monitors.forEach(lmonitor => {
-            let lmonitor_pack = [
-                lmonitor.x,
-                lmonitor.y,
-                lmonitor.scale,
-                lmonitor.transform,
-                lmonitor.primary,
-                []
-            ];
-            let monitors = lmonitor_pack[5];
-            for (let i = 0; i < lmonitor.monitors.length; i++) {
-                let connector = lmonitor.monitors[i][0];
-                let monitor = this.get_monitor(connector);
-                monitors.push([
-                    connector,
-                    monitor.current_mode_id,
-                    {
-                        'enable_underscanning': new GLib.Variant('b', monitor.is_underscanning)
-                    }
-                ]);
-            }
-            logical_monitors.push(lmonitor_pack);
-        });
-
-        if ('layout-mode' in this.properties) {
-            properties['layout-mode'] = new GLib.Variant('b', this.properties['layout-mode']);
-        }
-
-        return new GLib.Variant('(uua(iiduba(ssa{sv}))a{sv})', packing);
-    }
+    return new GLib.Variant('(uua(iiduba(ssa{sv}))a{sv})', packing);
+  }
 }

--- a/screen-rotate@shyzus.github.io/metadata.json
+++ b/screen-rotate@shyzus.github.io/metadata.json
@@ -3,15 +3,11 @@
   "description": "Enable screen rotation regardless of touch mode. Fork of Screen Autorotate by Kosmospredanie.",
   "url": "https://github.com/shyzus/gnome-shell-extension-screen-autorotate",
   "uuid": "screen-rotate@shyzus.github.io",
-  "version": 13,
+  "version": 99,
   "settings-schema": "org.gnome.shell.extensions.screen-rotate",
   "gettext-domain": "gnome-shell-extension-screen-rotate",
   "session-modes": ["user", "unlock-dialog"],
   "shell-version": [
-    "40",
-    "41",
-    "42",
-    "43",
-    "44"
+    "45"
   ]
 }

--- a/screen-rotate@shyzus.github.io/prefs.js
+++ b/screen-rotate@shyzus.github.io/prefs.js
@@ -15,209 +15,110 @@
 * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-const { GObject, Gtk, Gio, Adw } = imports.gi;
+import Gtk from 'gi://Gtk';
+import Gio from 'gi://Gio';
+import Adw from 'gi://Adw';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-function init() { }
+export default class MyExtensionPreferences extends ExtensionPreferences {
 
-function fillPreferencesWindow(window) {
-  const settings = ExtensionUtils.getSettings();
+  fillPreferencesWindow(window) {
+    window._settings = this.getSettings();
 
-  const page = new Adw.PreferencesPage();
-  window.add(page);
+    const page = new Adw.PreferencesPage();
+    window.add(page);
 
-  const orientationGroup = new Adw.PreferencesGroup();
-  orientationGroup.set_title('Orientation Settings')
-  page.add(orientationGroup);
+    const orientationGroup = new Adw.PreferencesGroup();
+    orientationGroup.set_title('Orientation Settings')
+    page.add(orientationGroup);
 
-  const debugGroup = new Adw.PreferencesGroup();
-  debugGroup.set_title('Debug Settings');
-  page.add(debugGroup);
+    const debugGroup = new Adw.PreferencesGroup();
+    debugGroup.set_title('Debug Settings');
+    page.add(debugGroup);
 
-  const invertHorizontalRow = new Adw.ActionRow({
-    title: 'Invert horizontal rotation'
-  });
-  orientationGroup.add(invertHorizontalRow);
+    const invertHorizontalRow = new Adw.ActionRow({
+      title: 'Invert horizontal rotation'
+    });
+    orientationGroup.add(invertHorizontalRow);
 
-  const invertVerticalRow = new Adw.ActionRow({
-    title: 'Invert vertical rotation'
-  });
-  orientationGroup.add(invertVerticalRow);
+    const invertVerticalRow = new Adw.ActionRow({
+      title: 'Invert vertical rotation'
+    });
+    orientationGroup.add(invertVerticalRow);
 
-  const flipOrientationRow = new Adw.ActionRow({
-    title: 'Flip orientation',
-    subtitle: 'e.g: Landscape to Portrait. Default is Landscape'
-  });
-  orientationGroup.add(flipOrientationRow);
+    const flipOrientationRow = new Adw.ActionRow({
+      title: 'Flip orientation',
+      subtitle: 'e.g: Landscape to Portrait. Default is Landscape'
+    });
+    orientationGroup.add(flipOrientationRow);
 
-  const setOffsetRow = new Adw.ActionRow({
-    title: 'Set orientation offset',
-    subtitle: 'Valid offset range: -3 to 3. Default is 0\nExperiment with this in case\
+    const setOffsetRow = new Adw.ActionRow({
+      title: 'Set orientation offset',
+      subtitle: 'Valid offset range: -3 to 3. Default is 0\nExperiment with this in case\
  orientation is incorrect due to the display being mounted in a non-landscape orientation\
  e.g PineTab2 or GPD Pocket 3'
-  });
+    });
 
-  orientationGroup.add(setOffsetRow);
+    orientationGroup.add(setOffsetRow);
 
-  const toggleLoggingRow = new Adw.ActionRow({
-    title: 'Enable debug logging',
-    subtitle: 'Use "journalctl /usr/bin/gnome-shell -f" to see log output.'
-  });
-  debugGroup.add(toggleLoggingRow);
+    const toggleLoggingRow = new Adw.ActionRow({
+      title: 'Enable debug logging',
+      subtitle: 'Use "journalctl /usr/bin/gnome-shell -f" to see log output.'
+    });
+    debugGroup.add(toggleLoggingRow);
 
-  const invertHorizontalRotationSwitch = new Gtk.Switch({
-    active: settings.get_boolean('invert-horizontal-rotation-direction'),
-    valign: Gtk.Align.CENTER,
-  });
+    const invertHorizontalRotationSwitch = new Gtk.Switch({
+      active: window._settings.get_boolean('invert-horizontal-rotation-direction'),
+      valign: Gtk.Align.CENTER,
+    });
 
-  const invertVerticalRotationSwitch = new Gtk.Switch({
-    active: settings.get_boolean('invert-vertical-rotation-direction'),
-    valign: Gtk.Align.CENTER,
-  });
+    const invertVerticalRotationSwitch = new Gtk.Switch({
+      active: window._settings.get_boolean('invert-vertical-rotation-direction'),
+      valign: Gtk.Align.CENTER,
+    });
 
-  const flipOrientationSwitch = new Gtk.Switch({
-    active: settings.get_boolean('flip-orientation'),
-    valign: Gtk.Align.CENTER,
-  });
+    const flipOrientationSwitch = new Gtk.Switch({
+      active: window._settings.get_boolean('flip-orientation'),
+      valign: Gtk.Align.CENTER,
+    });
 
-  const setOffsetSpinButton = Gtk.SpinButton.new_with_range(-3, 3, 1);
-  setOffsetSpinButton.value = settings.get_int('orientation-offset');
+    const setOffsetSpinButton = Gtk.SpinButton.new_with_range(-3, 3, 1);
+    setOffsetSpinButton.value = window._settings.get_int('orientation-offset');
 
-  const toggleLoggingSwitch = new Gtk.Switch({
-    active: settings.get_boolean('debug-logging'),
-    valign: Gtk.Align.CENTER
-  });
+    const toggleLoggingSwitch = new Gtk.Switch({
+      active: window._settings.get_boolean('debug-logging'),
+      valign: Gtk.Align.CENTER
+    });
 
-  settings.bind('invert-horizontal-rotation-direction',
-    invertHorizontalRotationSwitch, 'active', Gio.SettingsBindFlags.DEFAULT);
+    window._settings.bind('invert-horizontal-rotation-direction',
+      invertHorizontalRotationSwitch, 'active', Gio.SettingsBindFlags.DEFAULT);
 
-  settings.bind('invert-vertical-rotation-direction',
-    invertVerticalRotationSwitch, 'active', Gio.SettingsBindFlags.DEFAULT);
+    window._settings.bind('invert-vertical-rotation-direction',
+      invertVerticalRotationSwitch, 'active', Gio.SettingsBindFlags.DEFAULT);
 
-  settings.bind('flip-orientation',
-    flipOrientationSwitch, 'active', Gio.SettingsBindFlags.DEFAULT);
+    window._settings.bind('flip-orientation',
+      flipOrientationSwitch, 'active', Gio.SettingsBindFlags.DEFAULT);
 
-  settings.bind('orientation-offset',
-    setOffsetSpinButton, 'value', Gio.SettingsBindFlags.DEFAULT);
+    window._settings.bind('orientation-offset',
+      setOffsetSpinButton, 'value', Gio.SettingsBindFlags.DEFAULT);
 
-  settings.bind('debug-logging',
-    toggleLoggingSwitch, 'active', Gio.SettingsBindFlags.DEFAULT);
+    window._settings.bind('debug-logging',
+      toggleLoggingSwitch, 'active', Gio.SettingsBindFlags.DEFAULT);
 
-  invertHorizontalRow.add_suffix(invertHorizontalRotationSwitch);
-  invertHorizontalRow.activatable_widget = invertHorizontalRotationSwitch;
+    invertHorizontalRow.add_suffix(invertHorizontalRotationSwitch);
+    invertHorizontalRow.activatable_widget = invertHorizontalRotationSwitch;
 
-  invertVerticalRow.add_suffix(invertVerticalRotationSwitch);
-  invertVerticalRow.activatable_widget = invertVerticalRotationSwitch;
+    invertVerticalRow.add_suffix(invertVerticalRotationSwitch);
+    invertVerticalRow.activatable_widget = invertVerticalRotationSwitch;
 
-  flipOrientationRow.add_suffix(flipOrientationSwitch);
-  flipOrientationRow.activatable_widget = flipOrientationSwitch;
+    flipOrientationRow.add_suffix(flipOrientationSwitch);
+    flipOrientationRow.activatable_widget = flipOrientationSwitch;
 
-  setOffsetRow.add_suffix(setOffsetSpinButton);
-  setOffsetRow.activatable_widget = setOffsetSpinButton;
+    setOffsetRow.add_suffix(setOffsetSpinButton);
+    setOffsetRow.activatable_widget = setOffsetSpinButton;
 
-  toggleLoggingRow.add_suffix(toggleLoggingSwitch);
-  toggleLoggingRow.activatable_widget = toggleLoggingSwitch;
-
-  window._settings = settings;
-
-  // this.settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.screen-rotate');
-
-  //   // Create a parent widget that we'll return from this function
-  // const prefsWidget = new Gtk.Grid({
-  //   margin_top: 10,
-  //   margin_bottom: 10,
-  //   margin_start: 10,
-  //   margin_end: 10,
-  //   column_spacing: 12,
-  //   row_spacing: 12,
-  //   visible: true,
-  // });
-
-  // // Add a simple title and add it to the prefsWidget
-  // const title = new Gtk.Label({
-  //   label: `<b>${Me.metadata.name} Preferences</b>`,
-  //   halign: Gtk.Align.START,
-  //   use_markup: true,
-  //   visible: true,
-  // });
-  // prefsWidget.attach(title, 0, 0, 2, 1);
-
-  // // Create a label & switch for `flip-rotation-direction-horizontal`
-  // const flipRotationHorizontalLabel = new Gtk.Label({
-  //   label: 'Invert horizontal rotation:',
-  //   halign: Gtk.Align.START,
-  //   visible: true,
-  // });
-  // // Create a label & switch for `flip-rotation-direction-vertical`
-  // const flipRotationVerticalLabel = new Gtk.Label({
-  //   label: 'Invert vertical rotation:',
-  //   halign: Gtk.Align.START,
-  //   visible: true,
-  // });
-  // // Create a label & switch for `flip-orientation`
-  // const flipOrientationLabel = new Gtk.Label({
-  //   label: 'Flip orientation(default=Landscape):',
-  //   halign: Gtk.Align.START,
-  //   visible: true,
-  // });
-
-  // const portraitDisplayFlipLabel = new Gtk.Label({
-  //   label: 'Mirrored Portrait Display (ex: GPD Pocket 3):',
-  //   halign: Gtk.Align.START,
-  //   visible: true,
-  // });
-
-  // prefsWidget.attach(flipRotationHorizontalLabel, 0, 1, 1, 1);
-  // prefsWidget.attach(flipRotationVerticalLabel, 0, 2, 1, 1);
-  // prefsWidget.attach(flipOrientationLabel, 0, 3, 1, 1);
-  // prefsWidget.attach(portraitDisplayFlipLabel, 0, 4, 1, 1);
-
-  // this.flipHorizontalRotationSwitch = new Gtk.Switch({
-  //   halign: Gtk.Align.END,
-  //   visible: true,
-  // });
-
-  // this.flipVerticalRotationSwitch = new Gtk.Switch({
-  //   halign: Gtk.Align.END,
-  //   visible: true,
-  // });
-
-  // this.flipOrientationSwitch = new Gtk.Switch({
-  //   halign: Gtk.Align.END,
-  //   visible: true,
-  // });
-
-  // this.portraitDisplayFlipSwitch = new Gtk.Switch({
-  //   halign: Gtk.Align.END,
-  //   visible: true,
-  // });
-
-  // prefsWidget.attach(this.flipHorizontalRotationSwitch, 1, 1, 1, 1);
-  // prefsWidget.attach(this.flipVerticalRotationSwitch, 1, 2, 1, 1);
-  // prefsWidget.attach(this.flipOrientationSwitch, 1, 3, 1, 1);
-  // prefsWidget.attach(this.portraitDisplayFlipSwitch, 1, 4, 1, 1);
-
-  // // Bind the switch to the `flip-horizontal-rotation-direction` key
-  // this.settings.bind('flip-horizontal-rotation-direction', this.flipHorizontalRotationSwitch,
-  //   'active', Gio.SettingsBindFlags.DEFAULT,
-  // );
-
-  // // Bind the switch to the `flip-horizontal-rotation-direction` key
-  // this.settings.bind('flip-vertical-rotation-direction', this.flipVerticalRotationSwitch,
-  //   'active', Gio.SettingsBindFlags.DEFAULT,
-  // );
-
-  // // Bind the switch to the `flip-orientation` key
-  // this.settings.bind('flip-orientation', this.flipOrientationSwitch,
-  //   'active', Gio.SettingsBindFlags.DEFAULT,
-  // );
-
-  // this.settings.bind('portrait-display-flipped', this.portraitDisplayFlipSwitch, 
-  //   'active', Gio.SettingsBindFlags.DEFAULT,
-  // );
-
-  // // Return our widget which will be added to the window
-  // return prefsWidget;
+    toggleLoggingRow.add_suffix(toggleLoggingSwitch);
+    toggleLoggingRow.activatable_widget = toggleLoggingSwitch;
+  }
 }

--- a/screen-rotate@shyzus.github.io/rotator.js
+++ b/screen-rotate@shyzus.github.io/rotator.js
@@ -15,66 +15,61 @@
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
+import Gio from 'gi://Gio';
 
-'use strict';
-
-const { Gio, GLib } = imports.gi;
-
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const BusUtils = Me.imports.busUtils;
+import * as BusUtils from './busUtils.js';
 const connection = Gio.DBus.session;
 
-function call_dbus_method(method, params = null, handler) {
-    if (handler != undefined || handler != null) {
-        connection.call(
-            'org.gnome.Mutter.DisplayConfig',
-            '/org/gnome/Mutter/DisplayConfig',
-            'org.gnome.Mutter.DisplayConfig',
-            method,
-            params,
-            null,
-            Gio.DBusCallFlags.NONE,
-            -1,
-            null, handler);
-    } else {
-        connection.call(
-            'org.gnome.Mutter.DisplayConfig',
-            '/org/gnome/Mutter/DisplayConfig',
-            'org.gnome.Mutter.DisplayConfig',
-            method,
-            params,
-            null,
-            Gio.DBusCallFlags.NONE,
-            -1,
-            null);
-    }
-    
+export function call_dbus_method(method, params = null, handler) {
+  if (handler != undefined || handler != null) {
+    connection.call(
+      'org.gnome.Mutter.DisplayConfig',
+      '/org/gnome/Mutter/DisplayConfig',
+      'org.gnome.Mutter.DisplayConfig',
+      method,
+      params,
+      null,
+      Gio.DBusCallFlags.NONE,
+      -1,
+      null, handler);
+  } else {
+    connection.call(
+      'org.gnome.Mutter.DisplayConfig',
+      '/org/gnome/Mutter/DisplayConfig',
+      'org.gnome.Mutter.DisplayConfig',
+      method,
+      params,
+      null,
+      Gio.DBusCallFlags.NONE,
+      -1,
+      null);
+  }
+
 }
 
-function get_state() {
-    return new Promise((resolve, reject) => {
-        call_dbus_method('GetCurrentState', null, (connection, res) => {
-            try {
-                let reply = connection.call_finish(res);
-                let configState = new BusUtils.DisplayConfigState(reply)
-                resolve(configState);
-            } catch(err) {
-                reject(err);
-            }
-            
-        });
-    })
+export function get_state() {
+  return new Promise((resolve, reject) => {
+    call_dbus_method('GetCurrentState', null, (connection, res) => {
+      try {
+        let reply = connection.call_finish(res);
+        let configState = new BusUtils.DisplayConfigState(reply)
+        resolve(configState);
+      } catch (err) {
+        reject(err);
+      }
+
+    });
+  })
 }
 
-function rotate_to(transform) {
-    this.get_state().then( state => {
-        let builtin_monitor = state.builtin_monitor;
-        let logical_monitor = state.get_logical_monitor_for(builtin_monitor.connector);
-        logical_monitor.transform = transform;
-        let variant = state.pack_to_apply( BusUtils.Methods['temporary'] );
-        call_dbus_method('ApplyMonitorsConfig', variant);
-    }).catch(err => {
-        logError(err);
-    })
+export function rotate_to(transform) {
+  this.get_state().then(state => {
+    let builtin_monitor = state.builtin_monitor;
+    let logical_monitor = state.get_logical_monitor_for(builtin_monitor.connector);
+    logical_monitor.transform = transform;
+    let variant = state.pack_to_apply(BusUtils.Methods['temporary']);
+    call_dbus_method('ApplyMonitorsConfig', variant);
+  }).catch(err => {
+    console.error(err);
+  })
 }


### PR DESCRIPTION
Closes #20 

This pull request makes this extension compatible with GNOME 45. Also dropping support for GNOME versions before GNOME 45.

Note: This extension has multiple tags that do still support GNOME 40 to GNOME 44. At the time of writing being [v13](https://github.com/shyzus/gnome-shell-extension-screen-autorotate/releases/tag/v13).

It is recommended to use https://extensions.gnome.org for downloading/installing this extension to avoid any issues regarding supported versions.

Thanks to @luyatshimbalanga for creating this issue and provide information and testing along with @yfreund for testing as well.