### PR TITLE
17-fix-rotate

### DIFF
--- a/screen-rotate@shyzus.github.io/extension.js
+++ b/screen-rotate@shyzus.github.io/extension.js
@@ -193,7 +193,7 @@ class ScreenAutorotate {
         break;
     }
 
-    target += offset;
+    target = (target + offset) % 4;
     if (this._settings.get_boolean('debug-logging')) {
       console.debug(`sensor=${Orientation[orientation]}`);
       console.debug(`offset=${offset}`);

--- a/screen-rotate@shyzus.github.io/prefs.js
+++ b/screen-rotate@shyzus.github.io/prefs.js
@@ -55,7 +55,7 @@ export default class MyExtensionPreferences extends ExtensionPreferences {
 
     const setOffsetRow = new Adw.ActionRow({
       title: 'Set orientation offset',
-      subtitle: 'Valid offset range: -3 to 3. Default is 0\nExperiment with this in case\
+      subtitle: 'Valid offset range: 0 to 3. Default is 0\nExperiment with this in case\
  orientation is incorrect due to the display being mounted in a non-landscape orientation\
  e.g PineTab2 or GPD Pocket 3'
     });
@@ -83,7 +83,7 @@ export default class MyExtensionPreferences extends ExtensionPreferences {
       valign: Gtk.Align.CENTER,
     });
 
-    const setOffsetSpinButton = Gtk.SpinButton.new_with_range(-3, 3, 1);
+    const setOffsetSpinButton = Gtk.SpinButton.new_with_range(0, 3, 1);
     setOffsetSpinButton.value = window._settings.get_int('orientation-offset');
 
     const toggleLoggingSwitch = new Gtk.Switch({


### PR DESCRIPTION
I have made a change to the offset handling. Because a display only knows 4 orientations. An offset of +3 with an orientation of 3 would be 6 and that is not a reasonable value. Technically this is permissible but does not lead to a meaningful result. The solution is the modulo operator. In this case, negative values are no longer required. Whether you take -1 or 3 leads to the same result.

Unfortunately, it took a little longer because my Linux distribution has only now reached gnome 45. Should close #17 