### PR TITLE
GNOME 47 Support

### DIFF
--- a/screen-rotate@shyzus.github.io/metadata.json
+++ b/screen-rotate@shyzus.github.io/metadata.json
@@ -7,6 +7,6 @@
   "gettext-domain": "gnome-shell-extension-screen-rotate",
   "session-modes": ["user", "unlock-dialog"],
   "shell-version": [
-    "45", "46"
+    "45", "46", "47"
   ]
 }


### PR DESCRIPTION
Added GNOME 47 to supported shell version list.

Manual rotation tested on:

## Hardware Information:
- **Hardware Model:**                              Dell Inc. Latitude 5500
- **Memory:**                                      16.0 GiB
- **Processor:**                                   Intel® Core™ i5-8265U × 8
- **Graphics:**                                    Intel® UHD Graphics 620 (WHL GT2)
- **Disk Capacity:**                               256.1 GB

## Software Information:
- **Firmware Version:**                            1.33.0
- **OS Name:**                                     Fedora Linux 41.20240926.n.0 (Silverblue Prerelease)
- **OS Build:**                                    (null)
- **OS Type:**                                     64-bit
- **GNOME Version:**                               47
- **Windowing System:**                            Wayland
- **Kernel Version:**                              Linux 6.11.0-63.fc41.x86_64
